### PR TITLE
Funtoo Linux git-based Portage Tree Support

### DIFF
--- a/genlop
+++ b/genlop
@@ -982,6 +982,21 @@ sub rsync() {
 					print "     rsync'ed at >>> ", colored((scalar localtime "$1"), $COLORS{'green'}),"\n";
 				}
 			}
+			
+			if ($_ =~ m/^(.*?)\: \>\>\> Git pull in .*successful$/) {
+				if ($date_found) {
+					if (datecompare($1) <= 0) {
+						next;
+					}
+				}
+
+				if ($gmt_found) {
+					print "     Git pulled at >>> ", colored((scalar gmtime "$1"), $COLORS{'green'}),"\n";
+				}
+				else {
+					print "     Git pulled at >>> ", colored((scalar localtime "$1"), $COLORS{'green'}),"\n";
+				}
+			}
 		}
 		close($handle);
 	}


### PR DESCRIPTION
This commit makes genlop -r to work with Funtoo Linux git-based Portage tree.

I read that this is a long-term plan for Gentoo to support git-based Portage trees as well, so this commit might apply for Gentoo as well in the future.

Please let me know if I need to fill a request on bugs.gentoo.org for this feature...

Thanks!
