### PR TITLE
Add category when matching packages in genlop --current

### DIFF
--- a/genlop
+++ b/genlop
@@ -727,6 +727,7 @@ sub current()
 	{
 		my $e_current;
 		$ebuild_arg =~ s/(\+)/\\$1/g;
+		(my $cat = $ebuild_arg) =~ s/\/.*//g;
 		$ebuild_arg =~ s/.*\///g;
 		foreach my $logfile (@logfiles)
 		{
@@ -734,14 +735,14 @@ sub current()
 			open_file($logfile, \$handle);
 			while (<$handle>)
 			{
-				if (m/^(.*?)\:  \>\>\> emerge \((.*?) of (.*?)\)(.*?\/$ebuild_arg-[0-9].*?)to \//)
+				if (m/^(.*?)\:  \>\>\> emerge \((.*?) of (.*?)\)(.*?$cat\/$ebuild_arg-[0-9].*?)to \//)
 				{
 					$e_start     = $1;
 					$e_curmerge  = $2;
 					$e_lastmerge = $3;
 					$e_current   = $4;
 				}
-				if (m/^(.*?)\:  ::: completed .*?\) .*\/$ebuild_arg-[0-9].* to \//)
+				if (m/^(.*?)\:  ::: completed .*?\) .*$cat\/$ebuild_arg-[0-9].* to \//)
 				{
 					$e_end = $1;
 					$e_count++;


### PR DESCRIPTION
Fixes cases where the package exists in multiple categories but are not the same package e.g. virtual/ffmpeg vs media-libs/ffmpeg or other virtuals 
Please review if this should be done differently

One issue with adding category would be that packages having changed category won't match anymore