### PR TITLE
Limit nr of old merges to use to calculate estimated merge time.

### DIFF
--- a/genlop
+++ b/genlop
@@ -69,6 +69,7 @@ my (
 
 # variabili globali del programma
 my ($e_start, $e_end, $search_string, $m_count, $ebuild_found);
+my $current_maxcount = 20;
 
 # variabili di datecompare
 my ($fh, $elog);
@@ -738,6 +739,7 @@ sub current()
 		$ebuild_arg =~ s/(\+)/\\$1/g;
 		(my $cat = $ebuild_arg) =~ s/\/.*//g;
 		$ebuild_arg =~ s/.*\///g;
+		my @merges;
 		foreach my $logfile (@logfiles)
 		{
 			my $handle;
@@ -754,11 +756,19 @@ sub current()
 				if (m/^(.*?)\:  ::: completed .*?\) .*$cat\/$ebuild_arg-[0-9].* to \//)
 				{
 					$e_end = $1;
-					$e_count++;
-					&gtime($e_end - $e_start);
-					$tm_secondi += ($e_end - $e_start);
+					push(@merges,{ start => $e_start, end => $e_end });
 				}
 			}
+		}
+		if ( @merges > $current_maxcount )
+		{
+			# Use only latest $current_maxcount emerges to calculate mean mergetime
+			splice(@merges,0,scalar(@merges)-$current_maxcount)
+		}
+		foreach my $merge ( @merges )
+		{
+			$e_count++;
+			$tm_secondi += ( $merge->{end} - $merge->{start} );
 		}
 		$e_end = CORE::time();
 		&gtime($e_end - $e_start);


### PR DESCRIPTION
Most programs tend to take longer and longer time to compile over
time. This often leads to underestimated merge time.  This patch adds
a constant $current_maxcount (set to 20) that limits the nr of old
emerges to use for the estimation to the 20 latest emerges.

Example of genlop -c while emerging chromium.

$ genlop chromium | wc -l
189

$ genlop -t chromium | head -n 4
 * www-client/chromium

     Mon Aug 27 00:15:43 2012 >>> www-client/chromium-22.0.1229.14
       merge time: 11 minutes and 55 seconds.

$ genlop -t chromium | tail -n 3
     Mon Dec 26 18:58:14 2016 >>> www-client/chromium-56.0.2924.21
       merge time: 1 hour, 35 minutes and 15 seconds.


### With this patch

$ perl ./genlop -c

 Currently merging 1 out of 1

 * www-client/chromium-56.0.2924.21 

       current merge time: 13 seconds.
       ETA: 1 hour, 17 minutes and 53 seconds.

### Without it

$ genlop -c

 Currently merging 1 out of 1

 * www-client/chromium-56.0.2924.21 

       current merge time: 30 seconds.
       ETA: 45 minutes and 10 seconds.
