### PR TITLE
genlop -c: filter pid-ns-init duplicates (bug 677890)

### DIFF
--- a/genlop
+++ b/genlop
@@ -706,7 +706,7 @@ sub current()
 	# not check for sanity and have users check their FEATURES instead.
 	my @targets      = ();
 	my @sandbox_pids = ();
-	my @sandbox_procs = qx{ps ax -o pid,args | tail -n +2 | sed -e's/^ *//' | grep ' sandbox ' | grep -v ' grep '};
+	my @sandbox_procs = qx{ps ax -o pid,args | tail -n +2 | sed -e's/^ *//' | grep ' sandbox ' | grep -v -e ' grep ' -e 'pid-ns-init '};
 	my ($e_curmerge, $e_lastmerge);
 	foreach (@sandbox_procs)
 	{


### PR DESCRIPTION
The latest stable version of portage introduces a pid-ns-init
process which must be filtered in order to avoid duplicates.

Bug: https://bugs.gentoo.org/677890
Signed-off-by: Zac Medico <zmedico@gentoo.org>